### PR TITLE
fix: resolves bug where some settings got reset on IDE restart

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,6 +58,7 @@ repositories {
 // Dependencies are managed with Gradle version catalog - read more: https://docs.gradle.org/current/userguide/platforms.html#sub:version-catalog
 dependencies {
     testImplementation(libs.junit)
+    testImplementation("org.mockito.kotlin:mockito-kotlin:5.4.0")
 
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0")
     intellijPlatform {

--- a/src/main/kotlin/com/github/ramonvermeulen/dbtToolkit/services/DbtToolkitSettingsService.kt
+++ b/src/main/kotlin/com/github/ramonvermeulen/dbtToolkit/services/DbtToolkitSettingsService.kt
@@ -45,9 +45,9 @@ class DbtToolkitSettingsService : PersistentStateComponent<DbtToolkitSettingsSer
 
     private fun setInitialSettings(dbtProjectDir: String) {
         state.settingsDbtProjectDir = dbtProjectDir
-        state.settingsDbtTargetDir = "${dbtProjectDir}/target"
-        if (File("${dbtProjectDir}/.env").exists()) {
-            state.settingsDotEnvFilePath = "${dbtProjectDir}/.env"
+        state.settingsDbtTargetDir = "$dbtProjectDir/target"
+        if (File("$dbtProjectDir/.env").exists()) {
+            state.settingsDotEnvFilePath = "$dbtProjectDir/.env"
         }
         state.initialSettingsAreSet = true
     }

--- a/src/main/kotlin/com/github/ramonvermeulen/dbtToolkit/ui/DbtToolkitMainToolWindow.kt
+++ b/src/main/kotlin/com/github/ramonvermeulen/dbtToolkit/ui/DbtToolkitMainToolWindow.kt
@@ -84,7 +84,7 @@ class DbtToolkitMainToolWindow : ToolWindowFactory, DumbAware {
                 it,
                 object : VirtualFileVisitor<Any>() {
                     override fun visitFile(file: VirtualFile): Boolean {
-                        if (changeListManager.isIgnoredFile(file) || file.path.matches(Regex(".*/(target|dbt_packages)/.*"))) {
+                        if (changeListManager.isIgnoredFile(file) || file.path.matches(Regex(".*/(target|dbt_packages|.venv|venv)/.*"))) {
                             return false
                         }
                         if (file.name == "dbt_project.yml") {

--- a/src/test/kotlin/com/github/ramonvermeulen/dbtToolkit/services/DbtToolkitSettingsServiceTest.kt
+++ b/src/test/kotlin/com/github/ramonvermeulen/dbtToolkit/services/DbtToolkitSettingsServiceTest.kt
@@ -1,8 +1,12 @@
 package com.github.ramonvermeulen.dbtToolkit.services
 
+import com.intellij.mock.MockVirtualFile
 import com.intellij.openapi.components.service
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.testFramework.LightPlatformTestCase
 import junit.framework.TestCase
+import org.mockito.Mockito
+import java.io.ByteArrayInputStream
 
 class DbtToolkitSettingsServiceTest : LightPlatformTestCase() {
     private lateinit var settingsService: DbtToolkitSettingsService
@@ -19,6 +23,53 @@ class DbtToolkitSettingsServiceTest : LightPlatformTestCase() {
         } finally {
             super.tearDown()
         }
+    }
+
+    private fun createMockVirtualFile(targetPath: String): MockVirtualFile {
+        val mockFile = Mockito.mock(MockVirtualFile::class.java)
+        val mockParent = Mockito.mock(VirtualFile::class.java)
+        val yamlContent = """
+        name: test_project
+        model-paths: [models]
+        test-paths: [tests]
+        seed-paths: [seeds]
+        macro-paths: [macros]
+        """.trimIndent()
+        val inputStream = ByteArrayInputStream(yamlContent.toByteArray())
+
+        Mockito.`when`(mockFile.inputStream).thenReturn(inputStream)
+        Mockito.`when`(mockFile.parent).thenReturn(mockParent)
+        Mockito.`when`(mockParent.path).thenReturn(targetPath)
+        Mockito.`when`(mockFile.name).thenReturn("dbt_project.yml")
+
+        return mockFile
+    }
+
+    fun `test initial settings do not reset on subsequent parses`() {
+        val mockFile1 = createMockVirtualFile("mock/path")
+
+        settingsService.parseDbtProjectFile(mockFile1)
+        val initialState = settingsService.state
+
+        TestCase.assertTrue(initialState.initialSettingsAreSet)
+        TestCase.assertEquals("test_project", initialState.dbtProjectName)
+        TestCase.assertEquals("models", initialState.dbtModelPaths.firstOrNull())
+        TestCase.assertEquals("mock/path", initialState.settingsDbtProjectDir)
+        TestCase.assertEquals("mock/path/target", initialState.settingsDbtTargetDir)
+
+        // modify state to ensure it doesn't get reset
+        initialState.settingsDbtProjectDir = "modified_dir"
+        initialState.settingsDbtTargetDir = "modified_path"
+        settingsService.loadState(initialState)
+
+        // second call to parseDbtProjectFile with a new mock instance
+        val mockFile2 = createMockVirtualFile("mock/path2")
+        settingsService.parseDbtProjectFile(mockFile2)
+        val secondState = settingsService.state
+
+        // verify initial settings are not reset
+        TestCase.assertEquals("modified_dir", secondState.settingsDbtProjectDir)
+        TestCase.assertEquals("modified_path", secondState.settingsDbtTargetDir)
     }
 
     fun `test default state`() {


### PR DESCRIPTION
Should fix issue: https://github.com/ramonvermeulen/dbt-toolkit/issues/291

Should resolve a bug where some settings (e.g. target path, dbt project directory) got reset everytime the IDE restarts.