### PR TITLE
fix: project is already disposed by Disposer.register in the inint

### DIFF
--- a/src/main/kotlin/com/github/ramonvermeulen/dbtToolkit/ui/panels/LineagePanel.kt
+++ b/src/main/kotlin/com/github/ramonvermeulen/dbtToolkit/ui/panels/LineagePanel.kt
@@ -265,7 +265,6 @@ class LineagePanel(private val project: Project) :
     }
 
     override fun dispose() {
-        project.messageBus.dispose()
         javaScriptEngineProxy.dispose()
         browser.jbCefClient.dispose()
         browser.dispose()


### PR DESCRIPTION
Unindtended dispose that can cause a runtime exception